### PR TITLE
📛 The Names of Things: Look up ENS names and avatars for new wallets

### DIFF
--- a/background/constants/index.ts
+++ b/background/constants/index.ts
@@ -18,5 +18,10 @@ export const ALARMS = {
   },
 }
 
+export const SECOND = 1000
+export const MINUTE = 60 * SECOND
+export const HOUR = 60 * MINUTE
+export const DAY = 24 * HOUR
+
 export * from "./currencies"
 export * from "./networks"

--- a/background/lib/erc721.ts
+++ b/background/lib/erc721.ts
@@ -1,0 +1,77 @@
+import { Contract } from "ethers"
+import { BaseProvider } from "@ethersproject/providers"
+import { fetchJson } from "@ethersproject/web"
+
+import logger from "./logger"
+import { HexString, URI } from "../types"
+import { jtdValidatorFor } from "./validation"
+
+const abi = [
+  "function tokenURI(uint256 _tokenId) external view returns (string)",
+]
+
+/**
+ * Given an ERC-721 metadata-compliant token contract address and a token ID,
+ * return the specific token's URI.
+ */
+export async function getTokenURI(
+  provider: BaseProvider,
+  tokenAddress: HexString,
+  tokenID: bigint
+): Promise<URI | undefined> {
+  const tokenContract = new Contract(tokenAddress, abi).connect(provider)
+  return tokenContract.tokenURI(tokenID)
+}
+
+// JSON Type Definition for the ERC-721 Metadata Extension
+// https://eips.ethereum.org/EIPS/eip-721
+const metadataJTD = {
+  optionalProperties: {
+    name: { type: "string" },
+    description: { type: "string" },
+    image: { type: "string" },
+    title: { type: "string" }, // not found in 721, but seen in the wild
+    external_url: { type: "string" }, // not found in 721, but seen in the wild
+  },
+  additionalProperties: true,
+} as const
+
+const isValidMetadata = jtdValidatorFor(metadataJTD)
+
+export interface ERC721Metadata {
+  name: string | undefined
+  description: string | undefined
+  image: URI | undefined
+}
+
+/**
+ * Given a compliant token contract address and token ID, retrieve and parse the
+ * ERC-721 metadata.
+ */
+export async function getTokenMetadata(
+  provider: BaseProvider,
+  tokenAddress: HexString,
+  tokenID: bigint
+): Promise<ERC721Metadata | undefined> {
+  const uri = await getTokenURI(provider, tokenAddress, tokenID)
+  if (uri) {
+    const jsonResponse = await fetchJson(uri)
+
+    if (isValidMetadata(jsonResponse)) {
+      return {
+        name: jsonResponse.name,
+        description: jsonResponse.description,
+        image: jsonResponse.image,
+      }
+    }
+
+    logger.warn("Invalid ERC-721 metadata", tokenAddress, tokenID, jsonResponse)
+  } else {
+    logger.warn(
+      "No token URI was found, perhaps this isn't an ERC-721 metadata-compliant NFT?",
+      tokenAddress,
+      tokenID
+    )
+  }
+  return undefined
+}

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -8,6 +8,13 @@ export function normalizeEVMAddress(address: string | Buffer): HexString {
   return normalizeHexAddress(address)
 }
 
+export function sameEVMAddress(
+  address1: string | Buffer,
+  address2: string | Buffer
+): boolean {
+  return normalizeHexAddress(address1) === normalizeHexAddress(address2)
+}
+
 export function gweiToWei(value: number | bigint): bigint {
   return BigInt(utils.parseUnits(value.toString(), "gwei").toString())
 }

--- a/background/main.ts
+++ b/background/main.ts
@@ -13,6 +13,7 @@ import {
   ChainService,
   IndexingService,
   KeyringService,
+  NameService,
   ServiceCreatorFunction,
 } from "./services"
 
@@ -26,6 +27,8 @@ import {
   transactionSeen,
   blockSeen,
   updateAccountBalance,
+  updateENSName,
+  updateENSAvatar,
   emitter as accountSliceEmitter,
 } from "./redux-slices/accounts"
 import { activityEncountered } from "./redux-slices/activities"
@@ -138,6 +141,7 @@ export default class Main extends BaseService<never> {
       chainService
     )
     const keyringService = KeyringService.create()
+    const nameService = NameService.create(chainService)
 
     let savedReduxState = {}
     // Setting READ_REDUX_CACHE to false will start the extension with an empty
@@ -163,7 +167,8 @@ export default class Main extends BaseService<never> {
       await preferenceService,
       await chainService,
       await indexingService,
-      await keyringService
+      await keyringService,
+      await nameService
     )
   }
 
@@ -190,7 +195,12 @@ export default class Main extends BaseService<never> {
      * accounts, and signs messagees and transactions. The promise will be
      * resolved when the service is initialized.
      */
-    private keyringService: KeyringService
+    private keyringService: KeyringService,
+    /**
+     * A promise to the name service, responsible for resolving names to
+     * addresses and content.
+     */
+    private nameService: NameService
   ) {
     super({
       initialLoadWaitExpired: {
@@ -219,6 +229,7 @@ export default class Main extends BaseService<never> {
       this.chainService.startService(),
       this.indexingService.startService(),
       this.keyringService.startService(),
+      this.nameService.startService(),
     ])
   }
 
@@ -228,6 +239,7 @@ export default class Main extends BaseService<never> {
       this.chainService.stopService(),
       this.indexingService.stopService(),
       this.keyringService.stopService(),
+      this.nameService.stopService(),
     ])
 
     await super.internalStopService()
@@ -236,6 +248,7 @@ export default class Main extends BaseService<never> {
   async initializeRedux(): Promise<void> {
     this.connectIndexingService()
     this.connectKeyringService()
+    this.connectNameService()
     await this.connectChainService()
   }
 
@@ -322,6 +335,38 @@ export default class Main extends BaseService<never> {
 
     this.chainService.emitter.on("blockPrices", (blockPrices) => {
       this.store.dispatch(gasEstimates(blockPrices))
+    })
+  }
+
+  async connectNameService(): Promise<void> {
+    accountSliceEmitter.on("addAccount", async (addressNetwork) => {
+      let name: string | null = null
+      try {
+        name = await this.nameService.lookUpName(
+          addressNetwork.address,
+          addressNetwork.network
+        )
+        if (name) {
+          this.store.dispatch(updateENSName({ ...addressNetwork, name }))
+        }
+      } catch (err) {
+        logger.error(
+          "Error fetching ENS name for address",
+          addressNetwork.address,
+          err
+        )
+      }
+
+      if (name) {
+        const avatar = await this.nameService.lookUpAvatar(
+          addressNetwork.address,
+          addressNetwork.network
+        )
+
+        if (avatar) {
+          this.store.dispatch(updateENSAvatar({ ...addressNetwork, avatar }))
+        }
+      }
     })
   }
 

--- a/background/main.ts
+++ b/background/main.ts
@@ -339,35 +339,20 @@ export default class Main extends BaseService<never> {
   }
 
   async connectNameService(): Promise<void> {
-    accountSliceEmitter.on("addAccount", async (addressNetwork) => {
-      let name: string | null = null
-      try {
-        name = await this.nameService.lookUpName(
-          addressNetwork.address,
-          addressNetwork.network
-        )
-        if (name) {
-          this.store.dispatch(updateENSName({ ...addressNetwork, name }))
-        }
-      } catch (err) {
-        logger.error(
-          "Error fetching ENS name for address",
-          addressNetwork.address,
-          err
+    this.nameService.emitter.on(
+      "resolvedName",
+      async ({ from: { addressNetwork }, resolved: { name } }) => {
+        this.store.dispatch(updateENSName({ ...addressNetwork, name }))
+      }
+    )
+    this.nameService.emitter.on(
+      "resolvedAvatar",
+      async ({ from: { addressNetwork }, resolved: { avatar } }) => {
+        this.store.dispatch(
+          updateENSAvatar({ ...addressNetwork, avatar: avatar.toString() })
         )
       }
-
-      if (name) {
-        const avatar = await this.nameService.lookUpAvatar(
-          addressNetwork.address,
-          addressNetwork.network
-        )
-
-        if (avatar) {
-          this.store.dispatch(updateENSAvatar({ ...addressNetwork, avatar }))
-        }
-      }
-    })
+    )
   }
 
   async connectIndexingService(): Promise<void> {

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -27,8 +27,8 @@ type AccountData = {
   confirmedTransactions: ConfirmedEVMTransaction[]
   unconfirmedTransactions: AnyEVMTransaction[]
   ens: {
-    name: DomainName | null
-    avatar: URI | null
+    name?: DomainName
+    avatarURL?: URI
   }
 }
 
@@ -121,10 +121,7 @@ function newAccountData(address: HexString, network: Network): AccountData {
     balances: {},
     unconfirmedTransactions: [],
     confirmedTransactions: [],
-    ens: {
-      name: null,
-      avatar: null,
-    },
+    ens: {},
   }
 }
 

--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -234,7 +234,7 @@ const accountSlice = createSlice({
       )
       immerState.accountsData[address] = {
         ...baseAccountData,
-        ens: { ...baseAccountData.ens, name: addressNetworkAvatar.avatar },
+        ens: { ...baseAccountData.ens, avatarURL: addressNetworkAvatar.avatar },
       }
     },
     transactionSeen: (

--- a/background/services/index.ts
+++ b/background/services/index.ts
@@ -2,6 +2,7 @@ import ChainService from "./chain"
 import IndexingService from "./indexing"
 import KeyringService from "./keyring"
 import PreferenceService from "./preferences"
+import NameService from "./name"
 
 export type {
   ServiceLifecycleEvents,
@@ -9,4 +10,10 @@ export type {
   ServiceCreatorFunction,
 } from "./types"
 
-export { PreferenceService, ChainService, IndexingService, KeyringService }
+export {
+  PreferenceService,
+  ChainService,
+  IndexingService,
+  KeyringService,
+  NameService,
+}

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -1,8 +1,8 @@
 import { DomainName, HexString, URI } from "../../types"
 import { Network } from "../../networks"
 import { normalizeEVMAddress, sameEVMAddress } from "../../lib/utils"
-
 import { ETHEREUM } from "../../constants/networks"
+import { getTokenURI, getTokenMetadata } from "../../lib/erc721"
 
 import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
 import BaseService from "../base"
@@ -20,6 +20,7 @@ interface ResolvedAddressRecord {
   }
   system: "ENS" | "UNS"
 }
+
 interface ResolvedNameRecord {
   from: {
     addressNetwork: {
@@ -38,6 +39,18 @@ type Events = ServiceLifecycleEvents & {
   resolvedName: ResolvedNameRecord
 }
 
+// TODO eventually we want proper IPFS and Arweave support
+function storageGatewayURL(uri: URI): string {
+  // TODO proper URI parsing and replace
+  if (uri.match(/^ipfs:\/\//)) {
+    return `https://ipfs.io/ipfs/${uri.replace(/^ipfs:\/\//, "")}`
+  }
+  if (uri.match(/^ar:\/\//)) {
+    return `https://arweave.net/${uri.replace(/^ar:\/\//, "")}`
+  }
+  return uri
+}
+
 /**
  * The NameService is responsible for resolving human-readable names into
  * addresses and other metadata across multiple networks, caching where
@@ -46,6 +59,8 @@ type Events = ServiceLifecycleEvents & {
  * Initially, the service supports ENS on mainnet Ethereum.
  */
 export default class NameService extends BaseService<Events> {
+  private cachedEIP155AvatarURLs: Record<URI, URI> = {}
+
   /**
    * Create a new NameService. The service isn't initialized until
    * startService() is called and resolved.
@@ -142,14 +157,35 @@ export default class NameService extends BaseService<Events> {
     const avatar = await resolver.getText("avatar")
 
     if (avatar) {
-      // TODO this is naughty, do proper URI parsing
+      if (avatar.match(/^eip155:1\/erc721:/)) {
+        // check if we've cached the resolved URI, otherwise hit the chain
+        if (avatar.toLowerCase() in this.cachedEIP155AvatarURLs) {
+          // TODO properly cache this with any other non-ENS NFT stuff we do
+          return this.cachedEIP155AvatarURLs[avatar.toLowerCase()]
+        }
+        // these URIs look like eip155:1/erc721:0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6/2430
+        // check the spec for more details https://gist.github.com/Arachnid/9db60bd75277969ee1689c8742b75182
+        const components = avatar.split(/[:/]/)
+        if (components.length === 5) {
+          const metadata = await getTokenMetadata(
+            provider,
+            components[3],
+            BigInt(components[4])
+          )
+
+          if (metadata && metadata.image) {
+            const { image } = metadata
+            const resolvedGateway = storageGatewayURL(image)
+            this.cachedEIP155AvatarURLs[avatar] = resolvedGateway
+            return resolvedGateway
+          }
+        }
+      }
+      if (avatar.match(/^(ipfs|ar):/)) {
+        return storageGatewayURL(avatar)
+      }
       if (avatar.match(/^https:/)) {
         return avatar
-      }
-      if (avatar.match(/^ipfs:\/\//)) {
-        // TODO proper parsing and replace
-        // TODO real IPFS support!
-        return `https://ipfs.io/ipfs/${avatar.replace(/^ipfs:\/\//, "")}`
       }
     }
 

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -1,0 +1,160 @@
+import { DomainName, HexString, URI } from "../../types"
+import { Network } from "../../networks"
+import { normalizeEVMAddress, sameEVMAddress } from "../../lib/utils"
+
+import { ETHEREUM } from "../../constants/networks"
+
+import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
+import BaseService from "../base"
+import ChainService from "../chain"
+
+interface ResolvedAddressRecord {
+  from: {
+    name: DomainName
+  }
+  resolved: {
+    addressNetwork: {
+      address: HexString
+      network: Network
+    }
+  }
+  system: "ENS" | "UNS"
+}
+interface ResolvedNameRecord {
+  from: {
+    addressNetwork: {
+      address: HexString
+      network: Network
+    }
+  }
+  resolved: {
+    name: DomainName
+  }
+  system: "ENS" | "UNS"
+}
+
+type Events = ServiceLifecycleEvents & {
+  resolvedAddress: ResolvedAddressRecord
+  resolvedName: ResolvedNameRecord
+}
+
+/**
+ * The NameService is responsible for resolving human-readable names into
+ * addresses and other metadata across multiple networks, caching where
+ * appropriate.
+ *
+ * Initially, the service supports ENS on mainnet Ethereum.
+ */
+export default class NameService extends BaseService<Events> {
+  /**
+   * Create a new NameService. The service isn't initialized until
+   * startService() is called and resolved.
+   *
+   * @param chainService - Required for chain interactions.
+   * @returns A new, initializing ChainService
+   */
+  static create: ServiceCreatorFunction<
+    Events,
+    NameService,
+    [Promise<ChainService>]
+  > = async (chainService) => {
+    return new this(await chainService)
+  }
+
+  private constructor(private chainService: ChainService) {
+    super({})
+  }
+
+  async lookUpEthereumAddress(name: DomainName): Promise<HexString | null> {
+    // if doesn't end in .eth, throw. TODO turn on other domain endings soon +
+    // include support for UNS
+    if (!name.match(/.*\.eth$/)) {
+      throw new Error("Only .eth names can be resolved today.")
+    }
+    // TODO ENS lookups should work on Ethereum mainnet and a few testnets as well.
+    // This is going to be strange, though, as we'll be looking up ENS names for
+    // non-Ethereum networks (eg eventually Bitcoin).
+    const provider = this.chainService.pollingProviders.ethereum
+    // TODO cache name resolution and TTL
+    const address = await provider.resolveName(name)
+    if (!address || !address.match(/^0x[a-zA-Z0-9]*$/)) {
+      return null
+    }
+    const normalized = normalizeEVMAddress(address)
+    this.emitter.emit("resolvedAddress", {
+      from: { name },
+      resolved: { addressNetwork: { address: normalized, network: ETHEREUM } },
+      system: "ENS",
+    })
+    return normalized
+  }
+
+  async lookUpName(
+    address: HexString,
+    network: Network
+  ): Promise<DomainName | null> {
+    // TODO ENS lookups should work on a few testnets as well
+    if (network.chainID !== "1") {
+      throw new Error("Only Ethereum mainnet is supported.")
+    }
+    const provider = this.chainService.pollingProviders.ethereum
+    // TODO cache name resolution and TTL
+    const name = await provider.lookupAddress(address)
+    // TODO proper domain name validation ala RFC2181
+    if (
+      !name ||
+      !(
+        name.length <= 253 &&
+        name.match(
+          /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}\.([a-zA-Z0-9][a-zA-Z0-9-]{1,62}\.)*[a-zA-Z0-9][a-zA-Z0-9-]{1,62}/
+        )
+      )
+    ) {
+      return null
+    }
+    this.emitter.emit("resolvedName", {
+      from: { addressNetwork: { address, network } },
+      resolved: { name },
+      system: "ENS",
+    })
+    return name
+  }
+
+  async lookUpAvatar(
+    address: HexString,
+    network: Network
+  ): Promise<URI | null> {
+    // TODO ENS lookups should work on a few testnets as well
+    if (network.chainID !== "1") {
+      throw new Error("Only Ethereum mainnet is supported.")
+    }
+    const name = await this.lookUpName(address, network)
+    if (!name) {
+      return null
+    }
+    // TODO handle if it doesn't exist
+    const provider = this.chainService.pollingProviders.ethereum
+    const resolver = await provider.getResolver(name)
+    if (!sameEVMAddress(await resolver.getAddress(), address)) {
+      return null
+    }
+
+    const avatar = await resolver.getText("avatar")
+
+    if (avatar) {
+      // TODO this is naughty, do proper URI parsing
+      if (avatar.match(/^https:/)) {
+        return avatar
+      }
+      if (avatar.match(/^ipfs:\/\//)) {
+        // TODO proper parsing and replace
+        // TODO real IPFS support!
+        return `https://ipfs.io/ipfs/${avatar.replace(/^ipfs:\/\//, "")}`
+      }
+    }
+
+    return null
+  }
+}
+// TODO resolve other network addresses (eg Bitcoin)
+// TODO resolve content, eg IPFS hashes

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -8,26 +8,21 @@ import { ServiceCreatorFunction, ServiceLifecycleEvents } from "../types"
 import BaseService from "../base"
 import ChainService from "../chain"
 import logger from "../../lib/logger"
+import { AddressNetwork } from "../../accounts"
 
 interface ResolvedAddressRecord {
   from: {
     name: DomainName
   }
   resolved: {
-    addressNetwork: {
-      address: HexString
-      network: Network
-    }
+    addressNetwork: AddressNetwork
   }
   system: "ENS" | "UNS"
 }
 
 interface ResolvedNameRecord {
   from: {
-    addressNetwork: {
-      address: HexString
-      network: Network
-    }
+    addressNetwork: AddressNetwork
   }
   resolved: {
     name: DomainName

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -80,7 +80,9 @@ export default class NameService extends BaseService<Events> {
     super({})
   }
 
-  async lookUpEthereumAddress(name: DomainName): Promise<HexString | null> {
+  async lookUpEthereumAddress(
+    name: DomainName
+  ): Promise<HexString | undefined> {
     // if doesn't end in .eth, throw. TODO turn on other domain endings soon +
     // include support for UNS
     if (!name.match(/.*\.eth$/)) {
@@ -93,7 +95,7 @@ export default class NameService extends BaseService<Events> {
     // TODO cache name resolution and TTL
     const address = await provider.resolveName(name)
     if (!address || !address.match(/^0x[a-zA-Z0-9]*$/)) {
-      return null
+      return undefined
     }
     const normalized = normalizeEVMAddress(address)
     this.emitter.emit("resolvedAddress", {
@@ -107,7 +109,7 @@ export default class NameService extends BaseService<Events> {
   async lookUpName(
     address: HexString,
     network: Network
-  ): Promise<DomainName | null> {
+  ): Promise<DomainName | undefined> {
     // TODO ENS lookups should work on a few testnets as well
     if (network.chainID !== "1") {
       throw new Error("Only Ethereum mainnet is supported.")
@@ -125,7 +127,7 @@ export default class NameService extends BaseService<Events> {
         )
       )
     ) {
-      return null
+      return undefined
     }
     this.emitter.emit("resolvedName", {
       from: { addressNetwork: { address, network } },
@@ -138,20 +140,20 @@ export default class NameService extends BaseService<Events> {
   async lookUpAvatar(
     address: HexString,
     network: Network
-  ): Promise<URI | null> {
+  ): Promise<URL | undefined> {
     // TODO ENS lookups should work on a few testnets as well
     if (network.chainID !== "1") {
       throw new Error("Only Ethereum mainnet is supported.")
     }
     const name = await this.lookUpName(address, network)
     if (!name) {
-      return null
+      return undefined
     }
     // TODO handle if it doesn't exist
     const provider = this.chainService.pollingProviders.ethereum
     const resolver = await provider.getResolver(name)
     if (!sameEVMAddress(await resolver.getAddress(), address)) {
-      return null
+      return undefined
     }
 
     const avatar = await resolver.getText("avatar")
@@ -189,7 +191,7 @@ export default class NameService extends BaseService<Events> {
       }
     }
 
-    return null
+    return undefined
   }
 }
 // TODO resolve other network addresses (eg Bitcoin)

--- a/background/services/name/index.ts
+++ b/background/services/name/index.ts
@@ -167,12 +167,15 @@ export default class NameService extends BaseService<Events> {
         }
         // these URIs look like eip155:1/erc721:0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6/2430
         // check the spec for more details https://gist.github.com/Arachnid/9db60bd75277969ee1689c8742b75182
-        const components = avatar.split(/[:/]/)
-        if (components.length === 5) {
+        const [, , , erc721Address, nftID] = avatar.split(/[:/]/)
+        if (
+          typeof erc721Address !== "undefined" &&
+          typeof nftID !== "undefined"
+        ) {
           const metadata = await getTokenMetadata(
             provider,
-            components[3],
-            BigInt(components[4])
+            erc721Address,
+            BigInt(nftID)
           )
 
           if (metadata && metadata.image) {

--- a/background/types.ts
+++ b/background/types.ts
@@ -1,4 +1,26 @@
 /**
+ * Named type for strings that should be URIs.
+ *
+ * Currently *does not offer type safety*, just documentation value; see
+ * https://github.com/microsoft/TypeScript/issues/202 and
+ * https://github.com/microsoft/TypeScript/issues/41160 for TS features that
+ * would give this some more teeth. Right now, any `string` can be assigned
+ * into a variable of type `URI` and vice versa.
+ */
+export type URI = string
+
+/**
+ * Named type for strings that should be domain names.
+ *
+ * Currently *does not offer type safety*, just documentation value; see
+ * https://github.com/microsoft/TypeScript/issues/202 and
+ * https://github.com/microsoft/TypeScript/issues/41160 for TS features that
+ * would give this some more teeth. Right now, any `string` can be assigned
+ * into a variable of type `DomainName` and vice versa.
+ */
+export type DomainName = string
+
+/**
  * Named type for strings that should be hexadecimal numbers.
  *
  * Currently *does not offer type safety*, just documentation value; see

--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -18,15 +18,12 @@ export default function TopMenu(props: Props): ReactElement {
     ]
   })
 
-  const { name, avatar } = useBackgroundSelector((background) => {
+  const { name, avatarURL } = useBackgroundSelector((background) => {
     const data = background.account.accountsData[address.toLowerCase()]
     if (typeof data === "object") {
       return data.ens
     }
-    return {
-      name: null,
-      avatar: null,
-    }
+    return {}
   })
 
   return (
@@ -39,7 +36,7 @@ export default function TopMenu(props: Props): ReactElement {
           <TopMenuProfileButton
             address={truncatedAddress}
             nickname={name || undefined}
-            avatar={avatar || undefined}
+            avatar={avatarURL || undefined}
           />
         </button>
       </nav>

--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -11,8 +11,22 @@ interface Props {
 export default function TopMenu(props: Props): ReactElement {
   const { toggleOpenProtocolList, toggleOpenNotifications } = props
 
-  const truncatedAccountAddress = useBackgroundSelector((background) => {
-    return background.ui.selectedAccount?.truncatedAddress
+  const [address, truncatedAddress] = useBackgroundSelector((background) => {
+    return [
+      background.ui.selectedAccount?.address,
+      background.ui.selectedAccount?.truncatedAddress,
+    ]
+  })
+
+  const { name, avatar } = useBackgroundSelector((background) => {
+    const data = background.account.accountsData[address.toLowerCase()]
+    if (typeof data === "object") {
+      return data.ens
+    }
+    return {
+      name: null,
+      avatar: null,
+    }
   })
 
   return (
@@ -22,7 +36,11 @@ export default function TopMenu(props: Props): ReactElement {
           <TopMenuProtocolSwitcher />
         </button>
         <button type="button" onClick={toggleOpenNotifications}>
-          <TopMenuProfileButton account={truncatedAccountAddress} />
+          <TopMenuProfileButton
+            address={truncatedAddress}
+            nickname={name || undefined}
+            avatar={avatar || undefined}
+          />
         </button>
       </nav>
       <style jsx>

--- a/ui/components/TopMenu/TopMenuProfileButton.tsx
+++ b/ui/components/TopMenu/TopMenuProfileButton.tsx
@@ -8,7 +8,7 @@ export default function TopMenuProfileButton(props: {
   const { address, nickname, avatar } = props
   return (
     <button type="button">
-      {nickname || address}
+      {nickname ?? address}
       <div className="avatar" />
       <style jsx>
         {`
@@ -25,7 +25,7 @@ export default function TopMenuProfileButton(props: {
             height: 32px;
             background-color: white;
             margin-left: 8px;
-            background: url("${avatar || "./images/portrait.png"}");
+            background: url("${avatar ?? "./images/portrait.png"}");
           }
         `}
       </style>

--- a/ui/components/TopMenu/TopMenuProfileButton.tsx
+++ b/ui/components/TopMenu/TopMenuProfileButton.tsx
@@ -1,12 +1,14 @@
 import React, { ReactElement } from "react"
 
 export default function TopMenuProfileButton(props: {
-  account: string
+  address: string
+  nickname?: string
+  avatar?: string
 }): ReactElement {
-  const { account } = props
+  const { address, nickname, avatar } = props
   return (
     <button type="button">
-      {account}
+      {nickname || address}
       <div className="avatar" />
       <style jsx>
         {`
@@ -23,7 +25,7 @@ export default function TopMenuProfileButton(props: {
             height: 32px;
             background-color: white;
             margin-left: 8px;
-            background: url("./images/portrait.png");
+            background: url("${avatar || "./images/portrait.png"}");
           }
         `}
       </style>


### PR DESCRIPTION
An implementation of reverse ENS resolution, enabling ENS nicknames and avatars in the menu.

Includes

- [x] A basic name service (#225)
- [x] Reverse name and avatar resolution when 

Doesn't include

- A way to add a new read-only wallet by ENS name or to send funds to an ENS name (#411)
- Any sort of "address book" functionality

![Screenshot from 2021-11-11 18-36-57](https://user-images.githubusercontent.com/427505/141383991-08c2add7-3217-40a5-996d-b1989b3c6abb.png)

![Screenshot from 2021-11-11 18-17-45](https://user-images.githubusercontent.com/427505/141383998-03c04435-d617-466b-ab3f-dd755b2b02f2.png)

Closes #12
Closes #414 
