### PR TITLE
Add ENS validation and support for adding a read-only mode account

### DIFF
--- a/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
+++ b/ui/pages/Onboarding/OnboardingViewOnlyWallet.tsx
@@ -19,8 +19,12 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
     return /^(0x){1}[0-9a-fA-F]{40}$/i.test(checkAddress)
   }
 
+  function checkIfPlausibleENSAddress(checkAddress: string) {
+    return /^[a-z0-9-]{1,63}(.eth)$/i.test(checkAddress)
+  }
+
   const handleSubmitViewOnlyAddress = useCallback(async () => {
-    if (checkIfPlausibleETHAddress(address)) {
+    if (checkIfPlausibleETHAddress(address) || checkIfPlausibleENSAddress(address)) {
       await dispatch(
         addAddressNetwork({
           address,
@@ -29,7 +33,7 @@ export default function OnboardingViewOnlyWallet(): ReactElement {
       )
       setRedirect(true)
     } else {
-      alert("Please enter a valid address")
+      alert("Please enter a valid address or ENS address")
     }
   }, [dispatch, address])
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29030474/142422347-e4c24445-37ba-4a64-be3f-65349596205e.png)

Currently, we are only able to enter the Ethereum address(0x...) form in this preview mode, this patch added an ENS validation so that the ENS address can be also used. 