### PR TITLE
Move the content script into manifest.development.json

### DIFF
--- a/manifest/manifest.development.json
+++ b/manifest/manifest.development.json
@@ -1,5 +1,13 @@
 {
   "background": {
     "scripts": ["dev-utils/extension-reload.js"]
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "js": ["provider-bridge.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ]
 }

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -9,15 +9,6 @@
   "content_security_policy": "object-src 'self'; script-src 'self' blob: filesystem: 'unsafe-eval';",
   "web_accessible_resources": ["*.js", "*.json"],
 
-  "content_scripts": [
-    {
-      "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "js": ["provider-bridge.js"],
-      "run_at": "document_start",
-      "all_frames": true
-    }
-  ],
-
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
The content script is not yet ready to be released so we want to keep it confined into development mode. 

For this separation we use modes to handle different setups in the manifest.json
https://github.com/tallycash/tally-extension/blob/main/webpack.config.ts#L153

This PR moves the content script from the main manifest.json file into manifest.development.json so it get's picked up in development mode, but won't be included when we release a new version to the chrome store. 